### PR TITLE
Add only_msn and only_format arguments to dreams.utils.io

### DIFF
--- a/dreams/utils/io.py
+++ b/dreams/utils/io.py
@@ -478,7 +478,6 @@ def read_mzml(pth: Union[Path, str], verbose: bool = False, scan_range: Optional
         # Get peak list and check for problems
         peak_list = np.stack(spec.get_peaks())
         spec_problems = su.is_valid_peak_list(peak_list, relative_intensities=False, return_problems_list=True, verbose=verbose)
-        print(spec_problems)
         if spec_problems:
             if verbose:
                 print(f'Skipping spectrum {i} in {pth.name} with problems: {spec_problems}.')


### PR DESCRIPTION
This update introduces two optional arguments to improve flexibility in HDF5 exports:

- only_msn — allows saving only the 'MSn data' group when calling io.downloadpublicdata_to_hdf5s() or io.lcmsms_to_hdf5().
- only_format — enables saving only spectra matching the A, B, or C GeMS formats.

These additions are compatible with dreams.utils.io.merge_lcmsms_hdf5s(), that is needed for GeMS download pipeline.