### PR TITLE
Add HDF5 integrity checks, permissive data format, and robust merging

### DIFF
--- a/dreams/utils/dformats.py
+++ b/dreams/utils/dformats.py
@@ -153,6 +153,20 @@ class DataFormatC(DataFormat):
     high_intensity_thld = 0.1
 
 
+class DataFormatAll(DataFormat):
+    min_file_spectra = 1
+    max_ms_level = 100
+    min_peaks_n = 1
+    max_peaks_n = 128
+    min_charge = -100
+    max_charge = 100
+    min_intensity_ampl = 0.
+    max_tbxic_stdev = 1e6
+    max_prec_mz = 1e6
+    max_mz = 1e6
+    high_intensity_thld = 0.
+
+
 class DataFormatBuilder:
     def __init__(self, dformat_name):
         if dformat_name == 'A':
@@ -161,6 +175,8 @@ class DataFormatBuilder:
             self.dformat = DataFormatB()
         elif dformat_name == 'C':
             self.dformat = DataFormatC()
+        elif dformat_name == 'ALL':
+            self.dformat = DataFormatAll()
         elif dformat_name == 'A1':
             self.dformat = DataFormatA1()
         elif dformat_name == 'A2':
@@ -179,7 +195,7 @@ def assign_dformat(spec: np.ndarray, prec_mz: float, **kwargs) -> str:
         dformat = DataFormatBuilder(e).get_dformat()
         if dformat.val_spec(spec, prec_mz, **kwargs):
             return e
-    return '-'
+    return 'ALL'
 
 
 ### Legacy code

--- a/dreams/utils/io.py
+++ b/dreams/utils/io.py
@@ -160,6 +160,22 @@ def bytes_to_units(size_bytes, unit='MB'):
     return size_bytes / 1024 ** power
 
 
+def verify_hdf5_integrity(path: Union[str, Path]) -> bool:
+    """
+    Checks if an HDF5 file exists and can be opened/read without errors.
+    This detects corrupted headers or truncated files.
+    """
+    path = Path(path)
+    if not path.is_file() or path.stat().st_size == 0:
+        return False
+    try:
+        with h5py.File(path, 'r') as f:
+            _ = f.keys()
+            return True
+    except Exception:
+        return False
+
+
 def merge_ms_hdfs(in_hdf_pths, out_pth, group='MSn data', max_peaks_n=512, del_in=False, show_tqdm=True, logger=None,
                   add_file_name_dataset=True, mzs_dataset='mzs', intensities_dataset='intensities'):
     """
@@ -687,7 +703,8 @@ def read_lcmsms(
 
     # If order of spectra is invalid or insufficient do not continue the processing
     if order_of_spectra in [lcms.MSLevelsOrder.INVALID, lcms.MSLevelsOrder.EMPTY,
-                            lcms.MSLevelsOrder.SINGLE_MS1, lcms.MSLevelsOrder.UNIFORM_MS1]:
+                            lcms.MSLevelsOrder.SINGLE_MS1, lcms.MSLevelsOrder.UNIFORM_MS1,
+                            lcms.MSLevelsOrder.MISSING_MS1]:
         logger.info(f'Not processing the file because of {order_of_spectra}')
         #write_to_hdf(args, file_props=file_props, df_msn_data=None, prec_spectra_data=None, logger=logger)
         return None, None, None
@@ -1062,7 +1079,7 @@ def downloadpublicdata_to_hdf5s(downloads_log: Path, del_in=True, verbose=False,
 def merge_lcmsms_hdf5s(
         in_pths: Union[Path, Iterable[Path]],
         out_pth: Path,
-        dformat: str = 'A',
+        dformat: str = 'ALL',
         store_acc_est: bool = True,
         verbose: bool = True,
         compression: Optional[str] = 'gzip',
@@ -1071,9 +1088,13 @@ def merge_lcmsms_hdf5s(
     """
     Merge .hdf5 files generated with `lcmsms_to_hdf5`.
 
+    Uses a two-pass approach: first validates all inputs and collects union keys,
+    then merges with proper handling of heterogeneous datasets.
+
     Args:
         in_pths: Directory or iterable of .hdf5 files.
         out_pth: Output .hdf5 file.
+        dformat: Data format for filtering (default 'ALL' for permissive).
         store_acc_est: Whether to store instrument accuracy estimate.
         verbose: Verbose output.
         compression: Compression method for HDF5 datasets (e.g. 'gzip', None).
@@ -1082,83 +1103,253 @@ def merge_lcmsms_hdf5s(
 
     os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 
-    if not isinstance(in_pths, Path):
-        in_pths = Path(in_pths)
+    out_pth = Path(out_pth)
+    out_pth_resolved = out_pth.resolve()
 
-    if in_pths.is_dir():
-        in_pths = in_pths.glob('*.hdf5')
+    if isinstance(in_pths, (str, Path)):
+        in_pths = Path(in_pths)
+        if in_pths.is_dir():
+            candidates = sorted(in_pths.glob('*.hdf5'))
+        else:
+            candidates = [in_pths]
+    else:
+        candidates = sorted(Path(p) for p in in_pths)
+
+    candidates = [p for p in candidates if p.resolve() != out_pth_resolved]
 
     dformat_filters = dformats.DataFormatBuilder(dformat).get_dformat()
 
-    f_out = h5py.File(out_pth, 'w')
-    first_file = True
-    for in_pth in tqdm(list(in_pths), desc='Merging .hdf5 files', disable=not verbose):
+    excluded_msn_keys = {
+        'mzs', 'intensities', 'ion injection time', 'precursor id', 'def str'
+    }
+    metadata_fields = [
+        '#TBXICs', '#TBXICs(1)', 'MSLevelOrder', 'Ordered RT',
+        'TBXICs mean stdev', 'TBXICs median stdev', 'instrument name', 'name'
+    ]
+
+    def _normalize_attr(val):
+        if isinstance(val, bytes):
+            return val.decode('utf-8', errors='replace')
+        if isinstance(val, np.ndarray):
+            if val.shape == ():
+                val = val.item()
+            else:
+                return val
+        if isinstance(val, np.generic):
+            return val.item()
+        return val
+
+    def _coerce_metadata_value(field, value):
+        if value is None:
+            if field == 'Ordered RT':
+                return False
+            if field in {'#TBXICs', '#TBXICs(1)'}:
+                return -1
+            if field in {'TBXICs mean stdev', 'TBXICs median stdev'}:
+                return np.nan
+            return ''
+
+        value = _normalize_attr(value)
+        if field == 'Ordered RT':
+            return bool(value)
+        if field in {'#TBXICs', '#TBXICs(1)'}:
+            try:
+                return int(value)
+            except Exception:
+                return -1
+        if field in {'TBXICs mean stdev', 'TBXICs median stdev'}:
+            try:
+                return float(value)
+            except Exception:
+                return np.nan
+        return str(value)
+
+    def _fill_array(shape, dtype):
+        dtype = np.dtype(dtype)
+        str_info = h5py.check_string_dtype(dtype)
+        if str_info is not None:
+            return np.full(shape, '', dtype=dtype)
+        if dtype.kind in {'S', 'U'}:
+            fill = b'' if dtype.kind == 'S' else ''
+            return np.full(shape, fill, dtype=dtype)
+        if dtype.kind == 'b':
+            return np.zeros(shape, dtype=dtype)
+        if dtype.kind in {'i', 'u'}:
+            return np.full(shape, -1, dtype=dtype)
+        if dtype.kind == 'f':
+            return np.full(shape, np.nan, dtype=dtype)
+        return np.zeros(shape, dtype=dtype)
+
+    # Pass 1: Validate inputs and collect union keys
+    valid_inputs = []
+    union_keys = set()
+    key_specs = {}
+
+    for in_pth in candidates:
+        if not verify_hdf5_integrity(in_pth):
+            if verbose:
+                print(f'Skipping corrupted/invalid input file: {in_pth}')
+            continue
+
         try:
             with h5py.File(in_pth, 'a') as f_in:
+                if 'MSn data' not in f_in:
+                    if verbose:
+                        print(f"Skipping {in_pth} because 'MSn data' group is missing.")
+                    continue
 
-                n_spectra = f_in['MSn data']['mzs'].shape[0]
-                if not f_in.attrs['Ordered RT']:
+                msn_group = f_in['MSn data']
+                if 'mzs' not in msn_group or 'intensities' not in msn_group:
+                    if verbose:
+                        print(f'Skipping {in_pth} because required peak datasets are missing.')
+                    continue
+
+                n_spectra = msn_group['mzs'].shape[0]
+                if not bool(f_in.attrs.get('Ordered RT', False)):
                     continue
                 if n_spectra < dformat_filters.min_file_spectra:
                     continue
 
-                if 'dformat' not in f_in['MSn data']:
-                    dformat_array = np.empty(n_spectra, dtype=h5py.string_dtype())
-                    specs = np.stack([f_in['MSn data']['mzs'][:],
-                                      f_in['MSn data']['intensities'][:]], axis=1)
-                    prec_mzs = f_in['MSn data']['precursor mz'][:]
+                if 'dformat' not in msn_group:
+                    dformat_array = np.empty(n_spectra, dtype=h5py.string_dtype('utf-8'))
+                    specs = np.stack([msn_group['mzs'][:], msn_group['intensities'][:]], axis=1)
+                    prec_mzs = msn_group['precursor mz'][:]
                     for i in range(n_spectra):
                         dformat_array[i] = dformats.assign_dformat(specs[i], prec_mz=prec_mzs[i])
-                    f_in['MSn data'].create_dataset('dformat', data=dformat_array)
+                    msn_group.create_dataset('dformat', data=dformat_array)
 
-                spectra = np.stack([f_in['MSn data']['mzs'][:],
-                                    f_in['MSn data']['intensities'][:]], axis=1)
+                mergeable_keys = sorted(k for k in msn_group.keys() if k not in excluded_msn_keys)
+                for k in mergeable_keys:
+                    if k not in key_specs:
+                        ds = msn_group[k]
+                        key_specs[k] = {'dtype': ds.dtype, 'tail_shape': ds.shape[1:]}
+                union_keys.update(mergeable_keys)
+
+                metadata = {
+                    field: _coerce_metadata_value(field, f_in.attrs.get(field))
+                    for field in metadata_fields
+                }
+
+                valid_inputs.append({
+                    'path': Path(in_pth),
+                    'n_spectra': n_spectra,
+                    'metadata': metadata,
+                })
+        except Exception as e:
+            if verbose:
+                print(f'Skipping {in_pth} because of error: {e}')
+
+    if not valid_inputs:
+        raise ValueError('No valid input .hdf5 files were found for merging.')
+
+    union_keys = sorted(union_keys)
+
+    metadata_buffers = {field: [] for field in metadata_fields}
+    metadata_buffers['file_name'] = []
+
+    def _dataset_create_kwargs(dtype):
+        return {
+            'dtype': dtype,
+            'compression': compression,
+            'compression_opts': compression_level if compression == 'gzip' else None,
+        }
+
+    def _append_dataset(f_out, name, data, dtype):
+        data = np.asarray(data)
+        if name not in f_out:
+            f_out.create_dataset(
+                name,
+                data=data,
+                shape=data.shape,
+                maxshape=(None, *data.shape[1:]),
+                **_dataset_create_kwargs(dtype),
+            )
+        else:
+            f_out[name].resize(f_out[name].shape[0] + data.shape[0], axis=0)
+            f_out[name][-data.shape[0]:] = data
+
+    # Pass 2: Merge validated inputs
+    with h5py.File(out_pth, 'w') as f_out:
+        for file_id, entry in enumerate(
+            tqdm(valid_inputs, desc='Merging .hdf5 files', disable=not verbose)
+        ):
+            in_pth = entry['path']
+            n_spectra = entry['n_spectra']
+
+            with h5py.File(in_pth, 'r') as f_in:
+                msn_group = f_in['MSn data']
+
+                spectra = np.stack([msn_group['mzs'][:], msn_group['intensities'][:]], axis=1)
 
                 if spectra.shape[2] > dformat_filters.max_peaks_n:
                     spectra = su.trim_peak_list(spectra, dformat_filters.max_peaks_n)
                 elif spectra.shape[2] < dformat_filters.max_peaks_n:
                     spectra = su.pad_peak_list(spectra, dformat_filters.max_peaks_n)
 
-                datasets = [
-                    (SPECTRUM, spectra, f_in['MSn data']['mzs'].dtype),
-                    (FILE_NAME, [in_pth.stem] * n_spectra, h5py.string_dtype())
-                ]
-                exclude = {'mzs', 'intensities', 'ion injection time', 'precursor id', 'def str'}
-                all_keys = [k for k in f_in['MSn data'].keys() if k not in exclude]
-                datasets.extend(
-                    [(n, f_in['MSn data'][n][:], f_in['MSn data'][n].dtype) for n in all_keys]
+                _append_dataset(f_out, SPECTRUM, spectra, msn_group['mzs'].dtype)
+                _append_dataset(
+                    f_out, FILE_NAME,
+                    np.full(n_spectra, in_pth.stem, dtype=h5py.string_dtype('utf-8')),
+                    h5py.string_dtype('utf-8'),
                 )
-                if store_acc_est:
-                    datasets.append(
-                        ('instrument accuracy est.',
-                         np.repeat(f_in.attrs['TBXICs median stdev'], n_spectra),
-                         np.float32)
-                    )
+                _append_dataset(
+                    f_out, 'file_id',
+                    np.full(n_spectra, file_id, dtype=np.int32),
+                    np.int32,
+                )
 
-                for name, data, dtype in datasets:
-                    create_kwargs = dict(
-                        dtype=dtype,
-                        compression=compression,
-                        compression_opts=compression_level
-                        if compression == 'gzip' else None
-                    )
-
-                    if first_file:
-                        f_out.create_dataset(
-                            name,
-                            data=data,
-                            shape=data.shape if isinstance(data, np.ndarray) else (len(data),),
-                            maxshape=(None, *data.shape[1:]) if isinstance(data, np.ndarray) else (None,),
-                            **create_kwargs
-                        )
+                for key in union_keys:
+                    if key in msn_group:
+                        data = msn_group[key][:]
                     else:
-                        data_len = data.shape[0] if isinstance(data, np.ndarray) else len(data)
-                        f_out[name].resize(f_out[name].shape[0] + data_len, axis=0)
-                        f_out[name][-data_len:] = data
+                        spec = key_specs[key]
+                        data = _fill_array((n_spectra, *spec['tail_shape']), spec['dtype'])
+                    _append_dataset(f_out, key, data, key_specs[key]['dtype'])
 
-                first_file = False
-        except Exception as e:
-            print(f'Skipping {in_pth} because of error: {e}')
+                if store_acc_est:
+                    acc_est = _coerce_metadata_value(
+                        'TBXICs median stdev', f_in.attrs.get('TBXICs median stdev')
+                    )
+                    _append_dataset(
+                        f_out, 'instrument accuracy est.',
+                        np.full(n_spectra, acc_est, dtype=np.float32),
+                        np.float32,
+                    )
+
+            for field in metadata_fields:
+                metadata_buffers[field].append(entry['metadata'][field])
+            metadata_buffers['file_name'].append(in_pth.stem)
+
+        # Write per-file metadata group
+        metadata_group = f_out.create_group('metadata')
+        metadata_types = {
+            '#TBXICs': np.int64,
+            '#TBXICs(1)': np.int64,
+            'MSLevelOrder': h5py.string_dtype('utf-8'),
+            'Ordered RT': np.bool_,
+            'TBXICs mean stdev': np.float64,
+            'TBXICs median stdev': np.float64,
+            'instrument name': h5py.string_dtype('utf-8'),
+            'name': h5py.string_dtype('utf-8'),
+            'file_name': h5py.string_dtype('utf-8'),
+        }
+        for field, dtype in metadata_types.items():
+            metadata_group.create_dataset(
+                field,
+                data=np.asarray(metadata_buffers[field], dtype=dtype),
+                dtype=dtype,
+                compression=compression,
+                compression_opts=compression_level if compression == 'gzip' else None,
+            )
+
+        # Verify output integrity
+        lengths = {}
+        for name, obj in f_out.items():
+            if isinstance(obj, h5py.Group):
+                continue
+            lengths[name] = obj.shape[0]
+        if len(set(lengths.values())) != 1:
+            raise ValueError(f'Merged dataset length mismatch detected: {lengths}')
 
 
 def lsh_subset(in_pth, dformat, n_hplanes=None, bin_size=1, max_specs_per_lsh=None, seed=333):

--- a/dreams/utils/lcms.py
+++ b/dreams/utils/lcms.py
@@ -42,6 +42,9 @@ class MSLevelsOrder(Enum):
     # e.g. [2]
     SINGLE_MSN = auto()
 
+    # File misses MS1 precursor spectra
+    MISSING_MS1 = auto()
+
     # For all i: l_i = l_(i-1)
     # e.g. [1, 1, 1, 1]
     UNIFORM_MS1 = auto()
@@ -89,6 +92,10 @@ def get_order_of_spectra(msdata) -> MSLevelsOrder:
             return MSLevelsOrder.SINGLE_MS1
         else:
             return MSLevelsOrder.SINGLE_MSN
+
+    # Check that MS1 is present
+    if 1 not in ms_levels:
+        return MSLevelsOrder.MISSING_MS1
 
     # Go over all pairs of subsequent MS levels and classify
     # their difference to MSLevelOrder's
@@ -296,19 +303,27 @@ def remove_electromagnetic_spectra(msdata):
     return msdata
 
 def get_instrument_props(msdata):
+    try:
+        xics1, xics = get_tight_xics(msdata)
+        xics_stdev = [stats.stdev(xic[0]) for xic in xics]
 
-    xics1, xics = get_tight_xics(msdata)
-    xics_stdev = [stats.stdev(xic[0]) for xic in xics]
-
-    quality_props = {
-        'instrument name': msdata.getInstrument().getName(),
-        '#TBXICs(1)': len(xics1),
-        '#TBXICs': len(xics),
-        'TBXICs mean stdev': stats.mean(xics_stdev) if xics_stdev else None,
-        'TBXICs median stdev': stats.median(xics_stdev) if xics_stdev else None
-    }
-
-    return quality_props
+        quality_props = {
+            'instrument name': msdata.getInstrument().getName(),
+            '#TBXICs(1)': len(xics1),
+            '#TBXICs': len(xics),
+            'TBXICs mean stdev': stats.mean(xics_stdev) if xics_stdev else None,
+            'TBXICs median stdev': stats.median(xics_stdev) if xics_stdev else None
+        }
+        return quality_props
+    except Exception as e:
+        print(f'WARNING: Could not calculate instrument properties: {e}')
+        return {
+            'instrument name': 'Unknown',
+            '#TBXICs(1)': -1,
+            '#TBXICs': -1,
+            'TBXICs mean stdev': None,
+            'TBXICs median stdev': None
+        }
 
 
 def get_pwiz_stats(msdata):


### PR DESCRIPTION
## Summary

Improvements to HDF5 file merging, data format handling, and LC-MS/MS processing robustness developed while building the GeMS dataset construction pipeline:

- **`dformats.py`**: Add `DataFormatAll` permissive format class; change `assign_dformat()` fallback from `'-'` to `'ALL'`
- **`lcms.py`**: Add `MSLevelsOrder.MISSING_MS1` enum for files lacking MS1 spectra; make `get_instrument_props()` exception-safe
- **`io.py`**: Add `verify_hdf5_integrity()` function; rewrite `merge_lcmsms_hdf5s()` with two-pass union-key handling, metadata group, and integrity verification

## Motivation

When merging large collections of heterogeneous HDF5 files (different instruments, different dataset keys), the existing `merge_lcmsms_hdf5s()` would fail on:
- Corrupted/truncated HDF5 files
- Files with different sets of dataset keys
- Files missing MS1 spectra
- Instruments where TBXIC computation fails

The rewritten version handles all these cases gracefully with a two-pass approach (validate + merge), union-key collection for heterogeneous inputs, per-file metadata storage, and output integrity verification.

## Changes

### Commit 1: `dformats.py`
- New `DataFormatAll` class with permissive ranges (charge -100..100, m/z up to 1M)
- `DataFormatBuilder` gains `'ALL'` case
- `assign_dformat()` returns `'ALL'` instead of `'-'` for unmatched spectra

### Commit 2: `lcms.py`
- New `MSLevelsOrder.MISSING_MS1` enum value
- `get_order_of_spectra()` returns `MISSING_MS1` when MS1 level is absent
- `get_instrument_props()` wrapped in try/except with safe fallback defaults

### Commit 3: `io.py`
- New `verify_hdf5_integrity()` — validates HDF5 is readable before processing
- `read_lcmsms()` now skips `MISSING_MS1` files
- Rewritten `merge_lcmsms_hdf5s()`:
  - Default format changed from `'A'` to `'ALL'`
  - Excludes output file from input candidates
  - Two-pass approach: first validates all inputs and collects union keys, then merges
  - New helpers: `_normalize_attr`, `_coerce_metadata_value`, `_fill_array`, `_append_dataset`
  - Per-file metadata stored in dedicated `metadata` HDF5 group
  - `file_id` dataset tracks source file for each spectrum
  - Output integrity check (dataset length mismatch detection)

## Test plan

- [ ] Verify `merge_lcmsms_hdf5s()` produces valid merged HDF5 with heterogeneous inputs
- [ ] Verify `verify_hdf5_integrity()` correctly detects corrupted files
- [ ] Verify `MISSING_MS1` is correctly detected for MS2-only files
- [ ] Verify `DataFormatAll` accepts all spectra
- [ ] Verify existing tests still pass