### PR TITLE
Add scikit-learn dependency with version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "h5py==3.11.0",
         "rdkit==2023.9.6",
         "umap-learn==0.5.6",
+        "scikit-learn<1.6",
         "seaborn==0.13.2",
         "plotly==5.20.0",
         "ase==3.22.1",


### PR DESCRIPTION
@roman-bushuiev  Umap-learn==0.5.6 is not compatible with scikit-learn>1.6. The fitting of UMAP in https://dreams-docs.readthedocs.io/en/latest/tutorials/compute_embeddings.html doesn't work.

embs_umap = reducer.fit_transform(dreams_embs) 
gives the error: 
TypeError: check_array() got an unexpected keyword argument 'force_all_finite'

Setting scikit-learn<1.6 fixes the issue, since the keyword was changed in 1.6. 